### PR TITLE
add try catch block to handle got error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "whmcs-node",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/module/base.ts
+++ b/src/module/base.ts
@@ -1,5 +1,4 @@
 import got from 'got';
-import WhmcsApi from '..';
 import { WhmcsSetupOptions } from '../interface/whmcs.setup.options';
 
 export abstract class BaseModule {
@@ -13,15 +12,19 @@ export abstract class BaseModule {
     options.responsetype = 'json';
 
     return new Promise(async (resolve, reject) => {
-      const res = await got(this.options.apiUrl, {
-        method: 'post',
-        form: options
-      });
-
-      const data = JSON.parse(res.body);
-
-      if (data.result != "success") return reject(data);
-      resolve(data);
+      try {
+        const res = await got(this.options.apiUrl, {
+          method: 'post',
+          form: options
+        });
+  
+        const data = JSON.parse(res.body);
+  
+        if (data.result != "success") return reject(data);
+        resolve(data);
+      } catch (error) {
+        reject(error);
+      }
     });
   }
 }


### PR DESCRIPTION
Currently, if `got` api call returns error (4xx, 5xx status code), the error is not handled.
This adds a try catch block for those cases